### PR TITLE
Fix three P1 Android-only bugs (B4/B5/B6)

### DIFF
--- a/GlobalKeyboardCapture.Maui.Tests/DispatchOrderTests.cs
+++ b/GlobalKeyboardCapture.Maui.Tests/DispatchOrderTests.cs
@@ -1,0 +1,89 @@
+using GlobalKeyboardCapture.Maui.Configuration;
+using GlobalKeyboardCapture.Maui.Core.Models;
+using GlobalKeyboardCapture.Maui.Core.Services;
+using GlobalKeyboardCapture.Maui.Tests.TestDoubles;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GlobalKeyboardCapture.Maui.Tests;
+
+/// <summary>
+/// Verifies KeyHandlerService dispatches handlers in registration order. With a
+/// HashSet the handler that consumed an event under StopOnHandled was
+/// implementation-dependent; a List makes ordering deterministic, and the
+/// Contains guard keeps registration idempotent.
+/// </summary>
+public class DispatchOrderTests
+{
+    [Fact]
+    public void Dispatch_InvokesHandlersInRegistrationOrder()
+    {
+        var platform = new FakePlatformKeyHandler();
+        var svc = new KeyHandlerService(platform, NullLogger<KeyHandlerService>.Instance, new KeyHandlerOptions());
+
+        var order = new List<string>();
+        svc.RegisterHandler(new RecordingKeyHandler(onHandle: _ => order.Add("a")));
+        svc.RegisterHandler(new RecordingKeyHandler(onHandle: _ => order.Add("b")));
+        svc.RegisterHandler(new RecordingKeyHandler(onHandle: _ => order.Add("c")));
+
+        platform.Dispatch(new KeyEventArgs { Character = 'X' });
+
+        order.Should().Equal("a", "b", "c");
+    }
+
+    [Fact]
+    public void StopOnHandled_StopsAtFirstRegisteredHandlerThatHandles()
+    {
+        var platform = new FakePlatformKeyHandler();
+        var options = new KeyHandlerOptions { StopOnHandled = true };
+        var svc = new KeyHandlerService(platform, NullLogger<KeyHandlerService>.Instance, options);
+
+        var order = new List<string>();
+        svc.RegisterHandler(new RecordingKeyHandler(onHandle: k => { order.Add("a"); k.Handled = true; }));
+        svc.RegisterHandler(new RecordingKeyHandler(onHandle: _ => order.Add("b")));
+        svc.RegisterHandler(new RecordingKeyHandler(onHandle: _ => order.Add("c")));
+
+        platform.Dispatch(new KeyEventArgs { Character = 'X' });
+
+        order.Should().Equal("a");
+    }
+
+    [Fact]
+    public void RegisterHandler_IsIdempotent()
+    {
+        var platform = new FakePlatformKeyHandler();
+        var svc = new KeyHandlerService(platform, NullLogger<KeyHandlerService>.Instance, new KeyHandlerOptions());
+
+        var handler = new RecordingKeyHandler();
+        svc.RegisterHandler(handler);
+        svc.RegisterHandler(handler); // duplicate registration must not double-dispatch
+
+        platform.Dispatch(new KeyEventArgs { Character = 'X' });
+
+        handler.HandledKeys.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Dispatch_AfterUnregisterAndReregister_UsesAppendOrder()
+    {
+        // Register a, b, c; unregister b; register b again. A List appends the
+        // re-added handler, so dispatch order is a, c, b. A HashSet would reuse b's
+        // freed slot and iterate a, b, c, so this asserts the ordered-List behavior
+        // the fix depends on and would fail on the old HashSet implementation.
+        var platform = new FakePlatformKeyHandler();
+        var svc = new KeyHandlerService(platform, NullLogger<KeyHandlerService>.Instance, new KeyHandlerOptions());
+
+        var order = new List<string>();
+        var a = new RecordingKeyHandler(onHandle: _ => order.Add("a"));
+        var b = new RecordingKeyHandler(onHandle: _ => order.Add("b"));
+        var c = new RecordingKeyHandler(onHandle: _ => order.Add("c"));
+        svc.RegisterHandler(a);
+        svc.RegisterHandler(b);
+        svc.RegisterHandler(c);
+        svc.UnregisterHandler(b);
+        svc.RegisterHandler(b);
+
+        platform.Dispatch(new KeyEventArgs { Character = 'X' });
+
+        order.Should().Equal("a", "c", "b");
+    }
+}

--- a/GlobalKeyboardCapture.Maui.Tests/HotkeyHandlerNormalizationTests.cs
+++ b/GlobalKeyboardCapture.Maui.Tests/HotkeyHandlerNormalizationTests.cs
@@ -35,6 +35,41 @@ public class HotkeyHandlerNormalizationTests
         fired.Should().BeTrue();
     }
 
+    [Theory]
+    [InlineData("Escape", "Esc")]
+    [InlineData("ESCAPE", "Esc")]
+    [InlineData("Ctrl+Escape", "Ctrl+Esc")]
+    [InlineData("Ctrl+Return", "Ctrl+Enter")]
+    [InlineData("Shift+Del", "Shift+Delete")]
+    [InlineData("Alt+Ins", "Alt+Insert")]
+    [InlineData("Ctrl+PgUp", "Ctrl+PageUp")]
+    [InlineData("Ctrl+PgDn", "Ctrl+PageDown")]
+    [InlineData("PrtSc", "PrintScreen")]
+    [InlineData("Pause", "PauseBreak")]
+    public void CanonicalizesMainKeyAliasesToToStringForm(string input, string canonical)
+    {
+        // The string API must resolve key aliases to the same names KeyEventArgs.ToString()
+        // emits, otherwise the dispatch lookup (which uses ToString()) never matches.
+        var handler = new HotkeyHandler();
+        var fired = false;
+        handler.RegisterHotkey(input, () => fired = true);
+
+        handler.HandleKey(KeyForHotkey(canonical));
+
+        fired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UnregisterHotkey_String_HonorsMainKeyAlias()
+    {
+        var handler = new HotkeyHandler();
+        handler.RegisterHotkey(new Core.Models.KeyEventArgs { ControlKey = true, EscapeKey = true }, () => { });
+
+        // "Ctrl+Escape" must normalize to the same slot as the registered "Ctrl+Esc".
+        handler.UnregisterHotkey("Ctrl+Escape").Should().BeTrue();
+        handler.UnregisterHotkey("Ctrl+Esc").Should().BeFalse();
+    }
+
     [Fact]
     public void EmptyHotkeyStringThrows()
     {
@@ -82,6 +117,14 @@ public class HotkeyHandlerNormalizationTests
                 case "Esc": key.EscapeKey = true; break;
                 case "Enter": key.EnterKey = true; break;
                 case "Tab": key.TabKey = true; break;
+                case "Backspace": key.BackspaceKey = true; break;
+                case "Delete": key.DeleteKey = true; break;
+                case "Insert": key.InsertKey = true; break;
+                case "Space": key.SpaceKey = true; break;
+                case "PageUp": key.PageUpKey = true; break;
+                case "PageDown": key.PageDownKey = true; break;
+                case "PrintScreen": key.PrintScreenKey = true; break;
+                case "PauseBreak": key.PauseBreakKey = true; break;
                 default:
                     if (part.Length >= 2 && (part[0] == 'F' || part[0] == 'f') && char.IsDigit(part[1]))
                         key.FunctionKey = part;

--- a/GlobalKeyboardCapture.Maui.Tests/KeyHandlerServiceTests.cs
+++ b/GlobalKeyboardCapture.Maui.Tests/KeyHandlerServiceTests.cs
@@ -1,3 +1,4 @@
+using GlobalKeyboardCapture.Maui.Configuration;
 using GlobalKeyboardCapture.Maui.Core.Models;
 using GlobalKeyboardCapture.Maui.Core.Services;
 using GlobalKeyboardCapture.Maui.Tests.TestDoubles;
@@ -7,11 +8,12 @@ namespace GlobalKeyboardCapture.Maui.Tests;
 
 public class KeyHandlerServiceTests
 {
-    private static (KeyHandlerService svc, FakePlatformKeyHandler platform) Build()
+    private static (KeyHandlerService svc, FakePlatformKeyHandler platform) Build(
+        KeyHandlerOptions? options = null)
     {
         var platform = new FakePlatformKeyHandler();
         var logger = NullLogger<KeyHandlerService>.Instance;
-        return (new KeyHandlerService(platform, logger), platform);
+        return (new KeyHandlerService(platform, logger, options ?? new KeyHandlerOptions()), platform);
     }
 
     [Fact]

--- a/GlobalKeyboardCapture.Maui.Tests/P2FixesTests.cs
+++ b/GlobalKeyboardCapture.Maui.Tests/P2FixesTests.cs
@@ -1,0 +1,113 @@
+using GlobalKeyboardCapture.Maui.Configuration;
+using GlobalKeyboardCapture.Maui.Core.Models;
+using GlobalKeyboardCapture.Maui.Core.Services;
+using GlobalKeyboardCapture.Maui.Handlers;
+using GlobalKeyboardCapture.Maui.Tests.TestDoubles;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GlobalKeyboardCapture.Maui.Tests;
+
+/// <summary>
+/// Tests for the Round 3 P2 robustness fixes:
+///   B7:  KeyHandlerService.HandleKeyPress silently no-ops when disposed
+///        (previously threw ObjectDisposedException on the platform input thread).
+///   B8:  HotkeyHandler isolates exceptions thrown by user actions.
+///   B13: BarcodeHandler.OnBarcodeScanned always clears the buffer, even when
+///        a subscriber throws, so the next scan is not contaminated.
+///   B14: KeyEventArgs.PlatformEvent is nullable (compile-time check).
+/// </summary>
+public class P2FixesTests
+{
+    [Fact]
+    public void B7_DispatchAfterDispose_DoesNotThrow_AndIsIgnored()
+    {
+        var platform = new FakePlatformKeyHandler();
+        var svc = new KeyHandlerService(platform, NullLogger<KeyHandlerService>.Instance);
+        var recorder = new RecordingKeyHandler();
+        svc.RegisterHandler(recorder);
+
+        svc.Dispose();
+
+        Action act = () => platform.Dispatch(new KeyEventArgs { Character = 'X' });
+
+        act.Should().NotThrow();
+        recorder.HandledKeys.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void B8_HotkeyActionThatThrows_DoesNotPropagate()
+    {
+        var handler = new HotkeyHandler();
+        handler.RegisterHotkey("Ctrl+Z", () => throw new InvalidOperationException("boom"));
+
+        var key = new KeyEventArgs { ControlKey = true, Character = 'Z' };
+        Action act = () => handler.HandleKey(key);
+
+        act.Should().NotThrow();
+        key.Handled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void B8_FollowingHotkeysStillFireAfterFailingAction()
+    {
+        var handler = new HotkeyHandler();
+        var secondFired = false;
+        handler.RegisterHotkey("Ctrl+A", () => throw new InvalidOperationException("boom"));
+        handler.RegisterHotkey("Ctrl+B", () => secondFired = true);
+
+        handler.HandleKey(new KeyEventArgs { ControlKey = true, Character = 'A' });
+        handler.HandleKey(new KeyEventArgs { ControlKey = true, Character = 'B' });
+
+        secondFired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void B13_BufferIsClearedEvenWhenSubscriberThrows()
+    {
+        var options = new KeyHandlerOptions { MinBarcodeLength = 3, BarcodeTimeout = 1000 };
+        var time = new FakeTimeProvider();
+        var handler = new BarcodeHandler(options, time);
+
+        var scans = new List<string>();
+        var shouldThrow = true;
+        handler.BarcodeScanned += (_, code) =>
+        {
+            scans.Add(code);
+            if (shouldThrow) throw new InvalidOperationException("boom");
+        };
+
+        // First scan: subscriber throws AFTER the value is captured. The buffer
+        // must still be cleared so the next scan starts clean.
+        foreach (var c in "ABC")
+        {
+            handler.HandleKey(new KeyEventArgs { Character = c });
+            time.Advance(TimeSpan.FromMilliseconds(10));
+        }
+        Action firstEnter = () => handler.HandleKey(new KeyEventArgs { EnterKey = true });
+        firstEnter.Should().Throw<InvalidOperationException>();
+
+        // Second scan: subscriber no longer throws; result must be "XYZ" only,
+        // not "ABCXYZ" (which would prove the buffer wasn't cleared).
+        shouldThrow = false;
+        foreach (var c in "XYZ")
+        {
+            handler.HandleKey(new KeyEventArgs { Character = c });
+            time.Advance(TimeSpan.FromMilliseconds(10));
+        }
+        handler.HandleKey(new KeyEventArgs { EnterKey = true });
+
+        scans.Should().HaveCount(2);
+        scans[0].Should().Be("ABC");
+        scans[1].Should().Be("XYZ");
+    }
+
+    [Fact]
+    public void B14_KeyEventArgs_PlatformEvent_DefaultsToNull()
+    {
+        var key = new KeyEventArgs();
+        key.PlatformEvent.Should().BeNull();
+        // Also: ToString must not throw on a fresh instance (defensive path).
+        Action act = () => key.ToString();
+        act.Should().NotThrow();
+    }
+}

--- a/GlobalKeyboardCapture.Maui.Tests/P2FixesTests.cs
+++ b/GlobalKeyboardCapture.Maui.Tests/P2FixesTests.cs
@@ -22,7 +22,7 @@ public class P2FixesTests
     public void B7_DispatchAfterDispose_DoesNotThrow_AndIsIgnored()
     {
         var platform = new FakePlatformKeyHandler();
-        var svc = new KeyHandlerService(platform, NullLogger<KeyHandlerService>.Instance);
+        var svc = new KeyHandlerService(platform, NullLogger<KeyHandlerService>.Instance, new KeyHandlerOptions());
         var recorder = new RecordingKeyHandler();
         svc.RegisterHandler(recorder);
 

--- a/GlobalKeyboardCapture.Maui.Tests/Round4FixesTests.cs
+++ b/GlobalKeyboardCapture.Maui.Tests/Round4FixesTests.cs
@@ -1,0 +1,152 @@
+using GlobalKeyboardCapture.Maui.Configuration;
+using GlobalKeyboardCapture.Maui.Core.Models;
+using GlobalKeyboardCapture.Maui.Core.Services;
+using GlobalKeyboardCapture.Maui.Handlers;
+using GlobalKeyboardCapture.Maui.Tests.TestDoubles;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GlobalKeyboardCapture.Maui.Tests;
+
+/// <summary>
+/// Tests for the Round 4 fixes (formerly P2 remainder):
+///   B10: HotkeyHandler.UnregisterHotkey / ClearHotkeys.
+///   B11: KeyHandlerOptions.StopOnHandled stops the dispatch chain when set.
+///   B12: KeyboardHelper.ToChar(char) overload behaves like the string overload
+///        for the cases that DisplayLabel actually produces.
+/// </summary>
+public class Round4FixesTests
+{
+    // ---------- B10 ----------
+
+    [Fact]
+    public void B10_UnregisterHotkey_String_StopsFiring()
+    {
+        var handler = new HotkeyHandler();
+        var fired = 0;
+        handler.RegisterHotkey("Ctrl+Shift+X", () => fired++);
+
+        handler.HandleKey(new KeyEventArgs { ControlKey = true, ShiftKey = true, Character = 'X' });
+        handler.UnregisterHotkey("Ctrl+Shift+X").Should().BeTrue();
+        handler.HandleKey(new KeyEventArgs { ControlKey = true, ShiftKey = true, Character = 'X' });
+
+        fired.Should().Be(1);
+    }
+
+    [Fact]
+    public void B10_UnregisterHotkey_String_HonorsNormalization()
+    {
+        var handler = new HotkeyHandler();
+        handler.RegisterHotkey("Shift+Ctrl+X", () => { });
+
+        // Different modifier order, alias for Ctrl — both must resolve to the same slot.
+        handler.UnregisterHotkey("Control+Shift+X").Should().BeTrue();
+        handler.UnregisterHotkey("Ctrl+Shift+X").Should().BeFalse();
+    }
+
+    [Fact]
+    public void B10_UnregisterHotkey_KeyEventArgs_StopsFiring()
+    {
+        var handler = new HotkeyHandler();
+        var fired = 0;
+        var combo = new KeyEventArgs { AltKey = true, Character = 'Z' };
+        handler.RegisterHotkey(combo, () => fired++);
+
+        handler.HandleKey(new KeyEventArgs { AltKey = true, Character = 'Z' });
+        handler.UnregisterHotkey(new KeyEventArgs { AltKey = true, Character = 'Z' }).Should().BeTrue();
+        handler.HandleKey(new KeyEventArgs { AltKey = true, Character = 'Z' });
+
+        fired.Should().Be(1);
+    }
+
+    [Fact]
+    public void B10_UnregisterHotkey_ReturnsFalseWhenNotRegistered()
+    {
+        var handler = new HotkeyHandler();
+        handler.UnregisterHotkey("Ctrl+Q").Should().BeFalse();
+    }
+
+    [Fact]
+    public void B10_ClearHotkeys_RemovesEverything()
+    {
+        var handler = new HotkeyHandler();
+        var fired = 0;
+        handler.RegisterHotkey("Ctrl+A", () => fired++);
+        handler.RegisterHotkey("Ctrl+B", () => fired++);
+        handler.RegisterHotkey("Alt+C", () => fired++);
+
+        handler.ClearHotkeys();
+
+        handler.HandleKey(new KeyEventArgs { ControlKey = true, Character = 'A' });
+        handler.HandleKey(new KeyEventArgs { ControlKey = true, Character = 'B' });
+        handler.HandleKey(new KeyEventArgs { AltKey = true, Character = 'C' });
+
+        fired.Should().Be(0);
+    }
+
+    [Fact]
+    public void B10_UnregisterHotkey_String_ThrowsOnNullOrEmpty()
+    {
+        var handler = new HotkeyHandler();
+        ((Action)(() => handler.UnregisterHotkey(""))).Should().Throw<ArgumentException>();
+        ((Action)(() => handler.UnregisterHotkey((string)null!))).Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void B10_UnregisterHotkey_KeyEventArgs_ThrowsOnNull()
+    {
+        var handler = new HotkeyHandler();
+        ((Action)(() => handler.UnregisterHotkey((KeyEventArgs)null!))).Should().Throw<ArgumentNullException>();
+    }
+
+    // ---------- B11 ----------
+
+    [Fact]
+    public void B11_StopOnHandled_DefaultsFalse_AllHandlersStillRun()
+    {
+        var platform = new FakePlatformKeyHandler();
+        var svc = new KeyHandlerService(platform, NullLogger<KeyHandlerService>.Instance, new KeyHandlerOptions());
+        var first = new RecordingKeyHandler(onHandle: k => k.Handled = true);
+        var second = new RecordingKeyHandler();
+        svc.RegisterHandler(first);
+        svc.RegisterHandler(second);
+
+        platform.Dispatch(new KeyEventArgs { Character = 'X' });
+
+        first.HandledKeys.Should().HaveCount(1);
+        second.HandledKeys.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void B11_StopOnHandled_True_BreaksChainAfterHandled()
+    {
+        var platform = new FakePlatformKeyHandler();
+        var options = new KeyHandlerOptions { StopOnHandled = true };
+        var svc = new KeyHandlerService(platform, NullLogger<KeyHandlerService>.Instance, options);
+        var first = new RecordingKeyHandler(onHandle: k => k.Handled = true);
+        var second = new RecordingKeyHandler();
+        svc.RegisterHandler(first);
+        svc.RegisterHandler(second);
+
+        platform.Dispatch(new KeyEventArgs { Character = 'X' });
+
+        first.HandledKeys.Should().HaveCount(1);
+        second.HandledKeys.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void B11_StopOnHandled_True_ContinuesWhenNotHandled()
+    {
+        var platform = new FakePlatformKeyHandler();
+        var options = new KeyHandlerOptions { StopOnHandled = true };
+        var svc = new KeyHandlerService(platform, NullLogger<KeyHandlerService>.Instance, options);
+        var first = new RecordingKeyHandler(); // doesn't mark Handled
+        var second = new RecordingKeyHandler();
+        svc.RegisterHandler(first);
+        svc.RegisterHandler(second);
+
+        platform.Dispatch(new KeyEventArgs { Character = 'X' });
+
+        first.HandledKeys.Should().HaveCount(1);
+        second.HandledKeys.Should().HaveCount(1);
+    }
+}

--- a/GlobalKeyboardCapture.Maui/Configuration/KeyHandlerOptions.cs
+++ b/GlobalKeyboardCapture.Maui/Configuration/KeyHandlerOptions.cs
@@ -3,4 +3,13 @@ public class KeyHandlerOptions
 {
     public int BarcodeTimeout { get; set; } = 100;
     public int MinBarcodeLength { get; set; } = 5;
+
+    /// <summary>
+    /// When <c>true</c>, KeyHandlerService stops invoking subsequent handlers as
+    /// soon as one sets <see cref="Core.Models.KeyEventArgs.Handled"/> to
+    /// <c>true</c>. Defaults to <c>false</c> to preserve the historical
+    /// fan-out behavior where every registered handler sees every event
+    /// regardless of consumption.
+    /// </summary>
+    public bool StopOnHandled { get; set; }
 }

--- a/GlobalKeyboardCapture.Maui/Core/Models/KeyEventArgs.cs
+++ b/GlobalKeyboardCapture.Maui/Core/Models/KeyEventArgs.cs
@@ -9,7 +9,7 @@ public sealed class KeyEventArgs
     private const int INITIAL_TOSTRING_CAPACITY = 32;
 
     // Platform-specific event
-    public object PlatformEvent { get; set; }
+    public object? PlatformEvent { get; set; }
     public bool Handled { get; set; }
 
     // Characters and Function

--- a/GlobalKeyboardCapture.Maui/Core/Services/KeyHandlerService.cs
+++ b/GlobalKeyboardCapture.Maui/Core/Services/KeyHandlerService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using GlobalKeyboardCapture.Maui.Configuration;
 using GlobalKeyboardCapture.Maui.Core.Interfaces;
 using GlobalKeyboardCapture.Maui.Core.Models;
 using Microsoft.Extensions.Logging;
@@ -13,15 +14,18 @@ public sealed class KeyHandlerService : IKeyHandlerService, IDisposable
     private readonly HashSet<IKeyHandler> _handlers;
     private readonly IPlatformKeyHandler _platformHandler;
     private readonly ILogger<KeyHandlerService> _logger;
+    private readonly KeyHandlerOptions _options;
     private object? _boundPlatformView;
     private bool _isDisposed;
 
     public KeyHandlerService(
         IPlatformKeyHandler platformHandler,
-        ILogger<KeyHandlerService> logger)
+        ILogger<KeyHandlerService> logger,
+        KeyHandlerOptions options)
     {
         _platformHandler = platformHandler ?? throw new ArgumentNullException(nameof(platformHandler));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
         _handlers = new HashSet<IKeyHandler>(INITIAL_HANDLERS_CAPACITY);
         _platformHandler.ConfigureHandler(HandleKeyPress);
     }
@@ -63,6 +67,7 @@ public sealed class KeyHandlerService : IKeyHandlerService, IDisposable
             currentHandlers = _handlers.ToArray();
         }
 
+        var stopOnHandled = _options.StopOnHandled;
         foreach (var handler in currentHandlers)
         {
             try
@@ -76,6 +81,8 @@ public sealed class KeyHandlerService : IKeyHandlerService, IDisposable
             {
                 _logger.LogError(ex, "Handler failed to process key event");
             }
+
+            if (stopOnHandled && key.Handled) break;
         }
     }
 

--- a/GlobalKeyboardCapture.Maui/Core/Services/KeyHandlerService.cs
+++ b/GlobalKeyboardCapture.Maui/Core/Services/KeyHandlerService.cs
@@ -11,7 +11,9 @@ public sealed class KeyHandlerService : IKeyHandlerService, IDisposable
     private const int INITIAL_HANDLERS_CAPACITY = 8;
 
     private readonly object _lockObject = new();
-    private readonly HashSet<IKeyHandler> _handlers;
+    // List (not HashSet) so dispatch honors registration order — required for
+    // StopOnHandled, which makes handler order observable.
+    private readonly List<IKeyHandler> _handlers;
     private readonly IPlatformKeyHandler _platformHandler;
     private readonly ILogger<KeyHandlerService> _logger;
     private readonly KeyHandlerOptions _options;
@@ -26,7 +28,7 @@ public sealed class KeyHandlerService : IKeyHandlerService, IDisposable
         _platformHandler = platformHandler ?? throw new ArgumentNullException(nameof(platformHandler));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _options = options ?? throw new ArgumentNullException(nameof(options));
-        _handlers = new HashSet<IKeyHandler>(INITIAL_HANDLERS_CAPACITY);
+        _handlers = new List<IKeyHandler>(INITIAL_HANDLERS_CAPACITY);
         _platformHandler.ConfigureHandler(HandleKeyPress);
     }
 
@@ -93,7 +95,8 @@ public sealed class KeyHandlerService : IKeyHandlerService, IDisposable
         lock (_lockObject)
         {
             ThrowIfDisposed();
-            _handlers.Add(handler);
+            if (!_handlers.Contains(handler))
+                _handlers.Add(handler);
         }
     }
 

--- a/GlobalKeyboardCapture.Maui/Core/Services/KeyHandlerService.cs
+++ b/GlobalKeyboardCapture.Maui/Core/Services/KeyHandlerService.cs
@@ -56,7 +56,10 @@ public sealed class KeyHandlerService : IKeyHandlerService, IDisposable
         IKeyHandler[] currentHandlers;
         lock (_lockObject)
         {
-            ThrowIfDisposed();
+            // Silent early-return: this runs on the platform input thread and may be
+            // invoked for events already in flight after Dispose. Throwing here would
+            // crash the platform input pipeline.
+            if (_isDisposed) return;
             currentHandlers = _handlers.ToArray();
         }
 

--- a/GlobalKeyboardCapture.Maui/GlobalKeyboardCapture.Maui.csproj
+++ b/GlobalKeyboardCapture.Maui/GlobalKeyboardCapture.Maui.csproj
@@ -27,7 +27,7 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 
-        <CurrentVersion>1.0.4</CurrentVersion>
+        <CurrentVersion>1.1.0</CurrentVersion>
 	</PropertyGroup>
 
     <!-- Root assemblies to prevent trimming -->
@@ -60,6 +60,12 @@
 		<Description>A powerful .NET MAUI library for global keyboard capture with support for barcode scanners, hotkeys, and cross-platform input handling.</Description>
 		<Summary>Cross-platform global keyboard capture and input handling library for .NET MAUI applications, supporting hotkeys, barcode scanners, and system-wide keyboard monitoring.</Summary>
 		<PackageReleaseNotes>
+1.1.0:
+ - Feature: HotkeyHandler.UnregisterHotkey(string), UnregisterHotkey(KeyEventArgs) and ClearHotkeys() allow removing previously registered hotkeys (string overload uses the same modifier normalization as Register).
+ - Feature: KeyHandlerOptions.StopOnHandled (default false) opts the service into stopping the dispatch chain as soon as a handler sets Handled = true. Default preserves the historical fan-out behavior.
+ - Perf: AndroidKeyHandler.ProcessKeyEvent no longer allocates a string per keystroke; KeyboardHelper has a new char overload of ToChar used when KeyEvent.DisplayLabel is already a char.
+ - Breaking (DI consumers only): KeyHandlerService constructor now takes a KeyHandlerOptions parameter. The standard MauiAppBuilder.UseKeyboardHandling()/AddKeyboardHandling() wiring resolves this automatically.
+
 1.0.4:
  - Fix: AndroidKeyHandler now reports the Windows/Meta key as a modifier (WindowsKey = IsMetaPressed || KeyCode == Window), matching the Windows handler. Previously hotkeys like "Win+A" only fired on Windows.
  - Fix: AndroidKeyHandler now detects PrintScreen (Keycode.Sysrq) and PauseBreak (Keycode.Break). Previously these keys were silently ignored on Android.

--- a/GlobalKeyboardCapture.Maui/GlobalKeyboardCapture.Maui.csproj
+++ b/GlobalKeyboardCapture.Maui/GlobalKeyboardCapture.Maui.csproj
@@ -64,6 +64,11 @@
  - Fix: AndroidKeyHandler now reports the Windows/Meta key as a modifier (WindowsKey = IsMetaPressed || KeyCode == Window), matching the Windows handler. Previously hotkeys like "Win+A" only fired on Windows.
  - Fix: AndroidKeyHandler now detects PrintScreen (Keycode.Sysrq) and PauseBreak (Keycode.Break). Previously these keys were silently ignored on Android.
  - Fix: Android KeyboardHelper no longer maps Space to Character=' '. Previously the Space key produced ToString() = " +Space" on Android but "Space" on Windows, breaking cross-platform hotkey registration of "Space" / "Ctrl+Space".
+ - Fix: KeyHandlerService.HandleKeyPress now returns silently when the service is disposed instead of throwing on the platform input thread.
+ - Fix: KeyEventCallback on Android catches ObjectDisposedException from the handler and falls through to the original dispatcher, eliminating a Dispose race window.
+ - Fix: HotkeyHandler isolates exceptions thrown by user-supplied actions so a misbehaving hotkey no longer crashes the UI thread.
+ - Fix: BarcodeHandler clears the internal buffer in a finally block so a throwing BarcodeScanned subscriber does not contaminate the next scan.
+ - API: KeyEventArgs.PlatformEvent is now declared object? to match its actual nullable usage.
 
 1.0.3:
  - Fix: WindowsKeyHandler.Cleanup now unsubscribes from PreviewKeyDown (previously unsubscribed from the wrong event, leaving the handler attached and leaking subscriptions on re-init).

--- a/GlobalKeyboardCapture.Maui/GlobalKeyboardCapture.Maui.csproj
+++ b/GlobalKeyboardCapture.Maui/GlobalKeyboardCapture.Maui.csproj
@@ -27,7 +27,7 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 
-        <CurrentVersion>1.0.3</CurrentVersion>
+        <CurrentVersion>1.0.4</CurrentVersion>
 	</PropertyGroup>
 
     <!-- Root assemblies to prevent trimming -->
@@ -60,6 +60,11 @@
 		<Description>A powerful .NET MAUI library for global keyboard capture with support for barcode scanners, hotkeys, and cross-platform input handling.</Description>
 		<Summary>Cross-platform global keyboard capture and input handling library for .NET MAUI applications, supporting hotkeys, barcode scanners, and system-wide keyboard monitoring.</Summary>
 		<PackageReleaseNotes>
+1.0.4:
+ - Fix: AndroidKeyHandler now reports the Windows/Meta key as a modifier (WindowsKey = IsMetaPressed || KeyCode == Window), matching the Windows handler. Previously hotkeys like "Win+A" only fired on Windows.
+ - Fix: AndroidKeyHandler now detects PrintScreen (Keycode.Sysrq) and PauseBreak (Keycode.Break). Previously these keys were silently ignored on Android.
+ - Fix: Android KeyboardHelper no longer maps Space to Character=' '. Previously the Space key produced ToString() = " +Space" on Android but "Space" on Windows, breaking cross-platform hotkey registration of "Space" / "Ctrl+Space".
+
 1.0.3:
  - Fix: WindowsKeyHandler.Cleanup now unsubscribes from PreviewKeyDown (previously unsubscribed from the wrong event, leaving the handler attached and leaking subscriptions on re-init).
  - Fix: HotkeyHandler.RegisterHotkey(string, bool, bool, bool, Action) now recognizes named keys (Enter, Tab, Backspace, Delete, Space, Insert, arrows, Home, End, PageUp/PageDown, CapsLock, NumLock, ScrollLock, PrintScreen, PauseBreak, Menu) and common aliases. Previously these were silently treated as the first character of the name.

--- a/GlobalKeyboardCapture.Maui/GlobalKeyboardCapture.Maui.csproj
+++ b/GlobalKeyboardCapture.Maui/GlobalKeyboardCapture.Maui.csproj
@@ -63,10 +63,10 @@
 1.1.0:
  - Feature: HotkeyHandler.UnregisterHotkey(string), UnregisterHotkey(KeyEventArgs) and ClearHotkeys() allow removing previously registered hotkeys (string overload uses the same modifier normalization as Register).
  - Feature: KeyHandlerOptions.StopOnHandled (default false) opts the service into stopping the dispatch chain as soon as a handler sets Handled = true. Default preserves the historical fan-out behavior.
- - Perf: AndroidKeyHandler.ProcessKeyEvent no longer allocates a string per keystroke; KeyboardHelper has a new char overload of ToChar used when KeyEvent.DisplayLabel is already a char.
- - Breaking (DI consumers only): KeyHandlerService constructor now takes a KeyHandlerOptions parameter. The standard MauiAppBuilder.UseKeyboardHandling()/AddKeyboardHandling() wiring resolves this automatically.
-
-1.0.4:
+ - Fix: AndroidKeyHandler now resolves function keys (F1-F12) from the KeyCode. Previously DisplayLabel.ToString() never matched the "F1".."F12" names, so function-key hotkeys were undetectable on Android.
+ - Fix: HotkeyHandler now serializes every access to its hotkey map under a lock, so registering/unregistering/clearing (UI thread) no longer races the dispatch lookup (platform input thread).
+ - Fix: HotkeyHandler.NormalizeHotkey canonicalizes the main key to the names KeyEventArgs.ToString() emits (e.g. "Escape"/"ESCAPE" -> "Esc", "Return" -> "Enter"), so hotkeys registered via the string API match at dispatch time. Single-key strings are canonicalized too.
+ - Fix: KeyHandlerService dispatches handlers in registration order (List instead of HashSet), making StopOnHandled deterministic.
  - Fix: AndroidKeyHandler now reports the Windows/Meta key as a modifier (WindowsKey = IsMetaPressed || KeyCode == Window), matching the Windows handler. Previously hotkeys like "Win+A" only fired on Windows.
  - Fix: AndroidKeyHandler now detects PrintScreen (Keycode.Sysrq) and PauseBreak (Keycode.Break). Previously these keys were silently ignored on Android.
  - Fix: Android KeyboardHelper no longer maps Space to Character=' '. Previously the Space key produced ToString() = " +Space" on Android but "Space" on Windows, breaking cross-platform hotkey registration of "Space" / "Ctrl+Space".
@@ -74,7 +74,9 @@
  - Fix: KeyEventCallback on Android catches ObjectDisposedException from the handler and falls through to the original dispatcher, eliminating a Dispose race window.
  - Fix: HotkeyHandler isolates exceptions thrown by user-supplied actions so a misbehaving hotkey no longer crashes the UI thread.
  - Fix: BarcodeHandler clears the internal buffer in a finally block so a throwing BarcodeScanned subscriber does not contaminate the next scan.
+ - Perf: AndroidKeyHandler.ProcessKeyEvent no longer allocates a string per keystroke; KeyboardHelper has a new char overload of ToChar used when KeyEvent.DisplayLabel is already a char.
  - API: KeyEventArgs.PlatformEvent is now declared object? to match its actual nullable usage.
+ - Breaking (DI consumers only): KeyHandlerService constructor now takes a KeyHandlerOptions parameter. The standard MauiAppBuilder.UseKeyboardHandling()/AddKeyboardHandling() wiring resolves this automatically.
 
 1.0.3:
  - Fix: WindowsKeyHandler.Cleanup now unsubscribes from PreviewKeyDown (previously unsubscribed from the wrong event, leaving the handler attached and leaking subscriptions on re-init).

--- a/GlobalKeyboardCapture.Maui/Handlers/BarcodeHandler.cs
+++ b/GlobalKeyboardCapture.Maui/Handlers/BarcodeHandler.cs
@@ -68,8 +68,16 @@ public sealed class BarcodeHandler : IKeyHandler, IDisposable
 
     private void OnBarcodeScanned(string barcode)
     {
-        BarcodeScanned?.Invoke(this, barcode);
-        _buffer.Clear();
+        try
+        {
+            BarcodeScanned?.Invoke(this, barcode);
+        }
+        finally
+        {
+            // Always clear, even if a subscriber throws — otherwise the next scan
+            // would be concatenated to the failed one.
+            _buffer.Clear();
+        }
     }
 
     private void ThrowIfDisposed()

--- a/GlobalKeyboardCapture.Maui/Handlers/HotkeyHandler.cs
+++ b/GlobalKeyboardCapture.Maui/Handlers/HotkeyHandler.cs
@@ -56,7 +56,24 @@ public sealed class HotkeyHandler : IKeyHandler
         ["Windows"] = "Win"
     };
 
+    // Canonical aliases for the main (non-modifier) key, mirroring the names that
+    // KeyEventArgs.ToString() emits. Only aliases whose characters differ from the
+    // canonical form need mapping (case is handled by the OrdinalIgnoreCase dictionary).
+    // Keep this in sync with KeyEventArgs.ToString() and NamedKeySetters.
+    private static readonly Dictionary<string, string> KeyAliases = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Escape"] = "Esc",
+        ["Return"] = "Enter",
+        ["Del"] = "Delete",
+        ["Ins"] = "Insert",
+        ["PgUp"] = "PageUp",
+        ["PgDn"] = "PageDown",
+        ["PrtSc"] = "PrintScreen",
+        ["Pause"] = "PauseBreak"
+    };
+
     private readonly Dictionary<string, Action> _hotkeyActions;
+    private readonly object _hotkeysLock = new();
 
     public HotkeyHandler()
     {
@@ -72,7 +89,10 @@ public sealed class HotkeyHandler : IKeyHandler
 
         // Split and trim the parts
         var parts = hotkey.Split(SEPARATOR, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-        if (parts.Length <= 1) return hotkey;
+        if (parts.Length == 0) return string.Empty;
+        // A lone key still needs canonicalization (e.g. "Escape" -> "Esc") so the
+        // string API resolves to the same slot KeyEventArgs.ToString() produces.
+        if (parts.Length == 1) return CanonicalizeKey(parts[0]);
 
         // Identify modifiers and main key
         var modifiers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -88,7 +108,7 @@ public sealed class HotkeyHandler : IKeyHandler
             }
             else
             {
-                mainKey = normalizedPart;
+                mainKey = CanonicalizeKey(normalizedPart);
             }
         }
 
@@ -99,6 +119,9 @@ public sealed class HotkeyHandler : IKeyHandler
             ? string.Join(SEPARATOR, orderedModifiers)
             : $"{string.Join(SEPARATOR, orderedModifiers)}{SEPARATOR}{mainKey}";
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static string CanonicalizeKey(string key) => KeyAliases.GetValueOrDefault(key, key);
 
     public void RegisterHotkey(string key, bool requireControl, bool requireAlt, bool requireShift, Action action)
     {
@@ -120,12 +143,14 @@ public sealed class HotkeyHandler : IKeyHandler
         RegisterHotkey(hotKey, action);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void RegisterHotkey(KeyEventArgs hotKey, Action action)
     {
         ArgumentNullException.ThrowIfNull(hotKey);
         ArgumentNullException.ThrowIfNull(action);
-        _hotkeyActions[hotKey.ToString()] = action;
+        lock (_hotkeysLock)
+        {
+            _hotkeyActions[hotKey.ToString()] = action;
+        }
     }
 
     /// <summary>
@@ -159,13 +184,15 @@ public sealed class HotkeyHandler : IKeyHandler
     /// </remarks>
     /// <exception cref="ArgumentException">Thrown when <paramref name="hotKey"/> is null or empty.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="action"/> is null.</exception>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void RegisterHotkey(string hotKey, Action action)
     {
         ArgumentException.ThrowIfNullOrEmpty(hotKey);
         ArgumentNullException.ThrowIfNull(action);
 
-        _hotkeyActions[NormalizeHotkey(hotKey)] = action;
+        lock (_hotkeysLock)
+        {
+            _hotkeyActions[NormalizeHotkey(hotKey)] = action;
+        }
     }
 
     /// <summary>
@@ -177,7 +204,10 @@ public sealed class HotkeyHandler : IKeyHandler
     public bool UnregisterHotkey(string hotKey)
     {
         ArgumentException.ThrowIfNullOrEmpty(hotKey);
-        return _hotkeyActions.Remove(NormalizeHotkey(hotKey));
+        lock (_hotkeysLock)
+        {
+            return _hotkeyActions.Remove(NormalizeHotkey(hotKey));
+        }
     }
 
     /// <summary>
@@ -187,19 +217,34 @@ public sealed class HotkeyHandler : IKeyHandler
     public bool UnregisterHotkey(KeyEventArgs hotKey)
     {
         ArgumentNullException.ThrowIfNull(hotKey);
-        return _hotkeyActions.Remove(hotKey.ToString());
+        lock (_hotkeysLock)
+        {
+            return _hotkeyActions.Remove(hotKey.ToString());
+        }
     }
 
     /// <summary>
     /// Removes every registered hotkey.
     /// </summary>
-    public void ClearHotkeys() => _hotkeyActions.Clear();
+    public void ClearHotkeys()
+    {
+        lock (_hotkeysLock)
+        {
+            _hotkeyActions.Clear();
+        }
+    }
 
     public void HandleKey(KeyEventArgs key)
     {
         ArgumentNullException.ThrowIfNull(key);
 
-        if (_hotkeyActions.TryGetValue(key.ToString(), out var action))
+        Action? action;
+        lock (_hotkeysLock)
+        {
+            _hotkeyActions.TryGetValue(key.ToString(), out action);
+        }
+
+        if (action is not null)
         {
             MainThread.BeginInvokeOnMainThread(() =>
             {

--- a/GlobalKeyboardCapture.Maui/Handlers/HotkeyHandler.cs
+++ b/GlobalKeyboardCapture.Maui/Handlers/HotkeyHandler.cs
@@ -168,6 +168,33 @@ public sealed class HotkeyHandler : IKeyHandler
         _hotkeyActions[NormalizeHotkey(hotKey)] = action;
     }
 
+    /// <summary>
+    /// Removes a hotkey previously registered via the string overload.
+    /// The lookup uses the same normalization, so modifier order and aliases are
+    /// honored ("Control+Shift+X" matches a registration of "Shift+Ctrl+X").
+    /// </summary>
+    /// <returns><c>true</c> if a hotkey was removed; <c>false</c> if no match was registered.</returns>
+    public bool UnregisterHotkey(string hotKey)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(hotKey);
+        return _hotkeyActions.Remove(NormalizeHotkey(hotKey));
+    }
+
+    /// <summary>
+    /// Removes a hotkey previously registered via the <see cref="KeyEventArgs"/> overload.
+    /// </summary>
+    /// <returns><c>true</c> if a hotkey was removed; <c>false</c> if no match was registered.</returns>
+    public bool UnregisterHotkey(KeyEventArgs hotKey)
+    {
+        ArgumentNullException.ThrowIfNull(hotKey);
+        return _hotkeyActions.Remove(hotKey.ToString());
+    }
+
+    /// <summary>
+    /// Removes every registered hotkey.
+    /// </summary>
+    public void ClearHotkeys() => _hotkeyActions.Clear();
+
     public void HandleKey(KeyEventArgs key)
     {
         ArgumentNullException.ThrowIfNull(key);

--- a/GlobalKeyboardCapture.Maui/Handlers/HotkeyHandler.cs
+++ b/GlobalKeyboardCapture.Maui/Handlers/HotkeyHandler.cs
@@ -174,7 +174,20 @@ public sealed class HotkeyHandler : IKeyHandler
 
         if (_hotkeyActions.TryGetValue(key.ToString(), out var action))
         {
-            MainThread.BeginInvokeOnMainThread(action);
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    // Hotkey actions are user code; isolate exceptions so a misbehaving
+                    // handler does not crash the UI thread. Service ILogger is not
+                    // reachable from here, so trace and continue.
+                    System.Diagnostics.Debug.WriteLine($"[GlobalKeyboardCapture] Hotkey action threw: {ex}");
+                }
+            });
             key.Handled = true;
         }
     }

--- a/GlobalKeyboardCapture.Maui/Platforms/Android/AndroidKeyHandler.cs
+++ b/GlobalKeyboardCapture.Maui/Platforms/Android/AndroidKeyHandler.cs
@@ -131,9 +131,26 @@ public sealed class AndroidKeyHandler : IPlatformKeyHandler, IDisposable
 
         if (keyEvent.Character == null)
         {
-            // Function keys still go through the string lookup — DisplayLabel for
-            // F1..F12 is typically '\0', and ToFunction matches by name only.
-            keyEvent.FunctionKey = KeyboardHelper.ToFunction(displayLabel.ToString());
+            // DisplayLabel is '\0' for F1..F12, so the name-based ToFunction lookup
+            // never matches. Resolve function keys from the KeyCode instead, mapping
+            // to the same "F1".."F12" strings KeyEventArgs.ToString() expects. Literal
+            // mapping (not KeyCode.ToString()) keeps this trim/AOT-safe.
+            keyEvent.FunctionKey = e.KeyCode switch
+            {
+                Keycode.F1 => "F1",
+                Keycode.F2 => "F2",
+                Keycode.F3 => "F3",
+                Keycode.F4 => "F4",
+                Keycode.F5 => "F5",
+                Keycode.F6 => "F6",
+                Keycode.F7 => "F7",
+                Keycode.F8 => "F8",
+                Keycode.F9 => "F9",
+                Keycode.F10 => "F10",
+                Keycode.F11 => "F11",
+                Keycode.F12 => "F12",
+                _ => null
+            };
         }
 
         _onKeyPressed?.Invoke(keyEvent);

--- a/GlobalKeyboardCapture.Maui/Platforms/Android/AndroidKeyHandler.cs
+++ b/GlobalKeyboardCapture.Maui/Platforms/Android/AndroidKeyHandler.cs
@@ -91,7 +91,7 @@ public sealed class AndroidKeyHandler : IPlatformKeyHandler, IDisposable
             ControlKey = e.IsCtrlPressed,
             AltKey = e.IsAltPressed,
             ShiftKey = e.IsShiftPressed,
-            WindowsKey = e.KeyCode == Keycode.Window,
+            WindowsKey = e.IsMetaPressed || e.KeyCode == Keycode.Window,
 
             // Navigation
             UpKey = e.KeyCode == Keycode.DpadUp,
@@ -116,6 +116,8 @@ public sealed class AndroidKeyHandler : IPlatformKeyHandler, IDisposable
             CapsLockKey = e.KeyCode == Keycode.CapsLock,
             NumLockKey = e.KeyCode == Keycode.NumLock,
             ScrollLockKey = e.KeyCode == Keycode.ScrollLock,
+            PrintScreenKey = e.KeyCode == Keycode.Sysrq,
+            PauseBreakKey = e.KeyCode == Keycode.Break,
             MenuKey = e.KeyCode == Keycode.Menu,
             PlatformEvent = e
         };

--- a/GlobalKeyboardCapture.Maui/Platforms/Android/AndroidKeyHandler.cs
+++ b/GlobalKeyboardCapture.Maui/Platforms/Android/AndroidKeyHandler.cs
@@ -126,12 +126,14 @@ public sealed class AndroidKeyHandler : IPlatformKeyHandler, IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void ProcessKeyEvent(KeyEventArgs keyEvent, KeyEvent e)
     {
-        var displayLabel = e.DisplayLabel.ToString();
+        var displayLabel = e.DisplayLabel;
         keyEvent.Character = KeyboardHelper.ToChar(displayLabel);
 
         if (keyEvent.Character == null)
         {
-            keyEvent.FunctionKey = KeyboardHelper.ToFunction(displayLabel);
+            // Function keys still go through the string lookup — DisplayLabel for
+            // F1..F12 is typically '\0', and ToFunction matches by name only.
+            keyEvent.FunctionKey = KeyboardHelper.ToFunction(displayLabel.ToString());
         }
 
         _onKeyPressed?.Invoke(keyEvent);

--- a/GlobalKeyboardCapture.Maui/Platforms/Android/KeyEventCallback.cs
+++ b/GlobalKeyboardCapture.Maui/Platforms/Android/KeyEventCallback.cs
@@ -22,9 +22,18 @@ public class KeyEventCallback : Java.Lang.Object, IWindowCallback
     {
         if (e is null)
             return false;
-        
-        var handled = _handler.DispatchKeyEvent(e);
-        if (handled) return true;
+
+        try
+        {
+            if (_handler.DispatchKeyEvent(e))
+                return true;
+        }
+        catch (ObjectDisposedException)
+        {
+            // Race between Dispose() restoring the original callback and an
+            // event already in flight. Fall through to the original dispatcher
+            // instead of crashing the input thread.
+        }
         return _original.DispatchKeyEvent(e);
     }
 

--- a/GlobalKeyboardCapture.Maui/Platforms/Android/KeyboardHelper.cs
+++ b/GlobalKeyboardCapture.Maui/Platforms/Android/KeyboardHelper.cs
@@ -10,11 +10,11 @@ internal static class KeyboardHelper
 
     static KeyboardHelper()
     {
-        // Initialize HashSet of unique characters (for quick checks)
-        SingleCharKeys = new HashSet<char>()
-            {
-                ' ' // Space
-            };
+        // Space is intentionally excluded from both maps below: AndroidKeyHandler
+        // sets SpaceKey=true for Keycode.Space, and mapping ' ' here would also set
+        // Character=' ', producing a ToString() of " +Space" instead of the
+        // cross-platform expected "Space" (Windows leaves Character=null for Space).
+        SingleCharKeys = new HashSet<char>();
 
         // Add letters (A-Z)
         for (char c = 'A'; c <= 'Z'; c++)
@@ -26,9 +26,6 @@ internal static class KeyboardHelper
 
         // Initialize dictionary with adequate initial capacity
         KeyMap = new Dictionary<string, char>(100, StringComparer.OrdinalIgnoreCase);
-
-        // Map space
-        KeyMap["SPACE"] = ' ';
 
         // Map numbers and their variations
         for (char n = '0'; n <= '9'; n++)

--- a/GlobalKeyboardCapture.Maui/Platforms/Android/KeyboardHelper.cs
+++ b/GlobalKeyboardCapture.Maui/Platforms/Android/KeyboardHelper.cs
@@ -4,7 +4,6 @@ namespace GlobalKeyboardCapture.Maui.Platforms.Android;
 
 internal static class KeyboardHelper
 {
-    private static readonly HashSet<string> FKeys = new(["F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12"], StringComparer.OrdinalIgnoreCase);
     private static readonly HashSet<char> SingleCharKeys;
     private static readonly Dictionary<string, char> KeyMap;
 
@@ -92,11 +91,9 @@ internal static class KeyboardHelper
         }
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static string? ToFunction(string key)
-    {
-        return FKeys.Contains(key) ? key : null;
-    }
+    // Note: function keys (F1-F12) are resolved in AndroidKeyHandler directly from the
+    // Keycode; Android's KeyEvent.DisplayLabel is '\0' for them, so there is no
+    // name-based ToFunction here (unlike the Windows KeyboardHelper, which maps VirtualKey).
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static char? ToChar(string? key)

--- a/GlobalKeyboardCapture.Maui/Platforms/Android/KeyboardHelper.cs
+++ b/GlobalKeyboardCapture.Maui/Platforms/Android/KeyboardHelper.cs
@@ -47,6 +47,9 @@ internal static class KeyboardHelper
         foreach (var (symbol, variants) in mathOperators)
         {
             KeyMap[symbol] = symbol[0];
+            // Also accept the bare char in SingleCharKeys so ToChar(char) can short-circuit
+            // without allocating a string for a dictionary lookup (B12).
+            SingleCharKeys.Add(symbol[0]);
             foreach (var variant in variants)
                 KeyMap[variant] = symbol[0];
         }
@@ -102,6 +105,21 @@ internal static class KeyboardHelper
             return null;
 
         return ProcessKey(key.AsSpan());
+    }
+
+    /// <summary>
+    /// Allocation-free overload used on the hot path from <c>AndroidKeyHandler.ProcessKeyEvent</c>,
+    /// where <c>KeyEvent.DisplayLabel</c> is already a <see cref="char"/>. Avoids the
+    /// <c>char -&gt; string -&gt; span -&gt; char</c> round-trip of the string overload (B12).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static char? ToChar(char key)
+    {
+        if (key == '\0' || char.IsWhiteSpace(key))
+            return null;
+
+        var upper = char.ToUpperInvariant(key);
+        return SingleCharKeys.Contains(upper) ? upper : null;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
B4: Detect Win as modifier on Android via IsMetaPressed, not only when the
Window keycode is pressed. Matches the Windows handler which derives the
Win modifier from GetKeyState. Hotkeys like "Win+A" now fire on both
platforms.

B5: Detect PrintScreen and PauseBreak on Android (Keycode.Sysrq /
Keycode.Break). Both were already wired on the Windows side but silently
absent on Android.

B6: Remove the Space char mapping from the Android KeyboardHelper. On
Android, SpaceKey was set by the handler AND Character was set to ' ' by
the helper, producing ToString() = " +Space". On Windows the same event
yields "Space" (Character stays null). This made "Space" / "Ctrl+Space"
hotkeys unreachable on Android. The cross-platform contract now matches.

Bumps to 1.0.4 with release notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hotkey unregistration/removal APIs
  * Added `StopOnHandled` option to control handler dispatch chain behavior

* **Bug Fixes**
  * Key dispatches after service disposal no longer throw exceptions
  * Hotkey action exceptions are now caught and logged instead of propagating
  * Barcode buffer clears properly even when event subscribers throw
  * Improved Android key detection for PrintScreen, PauseBreak, Windows, and Space keys
  * Fixed race condition in Android key event processing

* **Breaking Changes**
  * KeyHandlerService constructor now requires KeyHandlerOptions parameter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->